### PR TITLE
Fix package.json to have correct syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "ionic-datepicker",
   "version": "0.9.0",
   "description": "A date picker for IONIC framework",
-  "main": [
-    "./dist/ionic-datepicker.bundle.min.js"
-  ],
+  "main": "./dist/ionic-datepicker.bundle.min.js",
   "scripts": {},
   "author": "https://github.com/rajeshwarpatlolla, rajeshwar.patlolla@gmail.com",
   "license": "MIT",


### PR DESCRIPTION
Currently using bower-like syntax, which makes it installing with `npm` impossible :-1: 

```
npm install git://github.com/rajeshwarpatlolla/ionic-datepicker.git#v0.9.0
npm ERR! Darwin 15.0.0
npm ERR! argv "/usr/local/Cellar/node/5.6.0/bin/node" "/usr/local/bin/npm" "install" "git://github.com/rajeshwarpatlolla/ionic-datepicker.git#v0.9.0"
npm ERR! node v5.6.0
npm ERR! npm  v3.7.3

npm ERR! Path must be a string. Received [ './dist/ionic-datepicker.bundle.min.js' ]
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/spriz/npm-debug.log
```

This works btw: `npm install --save https://github.com/Spriz/ionic-datepicker.git#patch-1`