### PR TITLE
Configuring popup and modal template locations

### DIFF
--- a/src/ionic-datepicker.provider.js
+++ b/src/ionic-datepicker.provider.js
@@ -11,6 +11,8 @@ angular.module('ionic-datepicker.provider', [])
       weeksList: ["S", "M", "T", "W", "T", "F", "S"],
       monthsList: ["Jan", "Feb", "March", "April", "May", "June", "July", "Aug", "Sept", "Oct", "Nov", "Dec"],
       templateType: 'popup',
+      popupTemplate: 'ionic-datepicker-popup.html',
+      modalTemplate: 'ionic-datepicker-modal.html',
       showTodayButton: false,
       closeOnSelect: false,
       disableWeekdays: []
@@ -192,7 +194,7 @@ angular.module('ionic-datepicker.provider', [])
         setDisabledDates($scope.mainObj);
       }
 
-      $ionicModal.fromTemplateUrl('ionic-datepicker-modal.html', {
+      $ionicModal.fromTemplateUrl(config.modalTemplate, {
         scope: $scope,
         animation: 'slide-in-up'
       }).then(function (modal) {
@@ -266,7 +268,7 @@ angular.module('ionic-datepicker.provider', [])
 
         if ($scope.mainObj.templateType.toLowerCase() == 'popup') {
           $scope.popup = $ionicPopup.show({
-            templateUrl: 'ionic-datepicker-popup.html',
+            templateUrl: config.popupTemplate,
             scope: $scope,
             cssClass: 'ionic_datepicker_popup',
             buttons: buttons


### PR DESCRIPTION
I find it useful to let the library user decide where the HTML templates of modal and popup are located in his application. On this way he is able to write own templates when he does not use the bundled JS file, including default CSS and templates.

This modification does not effect the built bundle so it's only bringing advantages in my opinion.