### PR TITLE
fixed year not selected bug

### DIFF
--- a/src/ionic-datepicker-modal.html
+++ b/src/ionic-datepicker-modal.html
@@ -5,8 +5,8 @@
   <ion-content class="ionic_datepicker_modal_content">
     <div class="">
       <div class="row text-center">
-        <div class="col col-10 left_arrow">
-          <button class="button-clear font_22px" ng-click="prevMonth()"
+        <div class="col col-10 left_arrow" ng-click="prevMonth()">
+          <button class="button-clear font_22px"
                   ng-class="{'pointer_events_none':((firstDayEpoch - 86400000) < fromDate)}">
             <i class="icon ion-chevron-left"></i>
           </button>
@@ -26,13 +26,13 @@
             <div class="col-50 padding_left_5px">
               <label class="item item-input item-select year_select">
                 <span class="input-label">&nbsp;</span>
-                <select ng-model="currentYear" ng-change="yearChanged(currentYear)" ng-options="year for year in yearsList"></select>
+                <select ng-model="currentYear" ng-options="year for year in yearsList track by year" ng-change="yearChanged(currentYear)"></select>
               </label>
             </div>
           </div>
         </div>
-        <div class="col col-10 right_arrow">
-          <button class=" button-clear font_22px" ng-click="nextMonth()"
+        <div class="col col-10 right_arrow" ng-click="nextMonth()">
+          <button class=" button-clear font_22px"
                   ng-class="{'pointer_events_none':((lastDayEpoch + 86400000)> toDate)}">
             <i class="icon ion-chevron-right"></i>
           </button>

--- a/src/ionic-datepicker-popup.html
+++ b/src/ionic-datepicker-popup.html
@@ -1,8 +1,8 @@
 <div class="selected_date_full">{{selctedDateEpoch | date : mainObj.dateFormat}}</div>
 <div class="date_selection">
   <div class="row show_nav">
-    <div class="col-10 prev_btn_section">
-      <button class="button-clear" ng-click="prevMonth()"
+    <div class="col-10 prev_btn_section" ng-click="prevMonth()">
+      <button class="button-clear"
               ng-class="{'pointer_events_none':((firstDayEpoch - 86400000) < fromDate)}">
         <i class="icon ion-chevron-left"></i>
       </button>
@@ -22,13 +22,13 @@
         <div class="col-50 padding_left_5px">
           <label class="item item-input item-select year_select">
             <span class="input-label">&nbsp;</span>
-            <select ng-model="currentYear" ng-change="yearChanged(currentYear)" ng-options="year for year in yearsList"></select>
+              <select ng-model="currentYear" ng-options="year for year in yearsList track by year" ng-change="yearChanged(currentYear)"></select>
           </label>
         </div>
       </div>
     </div>
-    <div class="col-10 next_btn_section">
-      <button class="button-clear" ng-click="nextMonth()"
+    <div class="col-10 next_btn_section" ng-click="nextMonth()">
+      <button class="button-clear"
               ng-class="{'pointer_events_none':((lastDayEpoch + 86400000)> toDate)}">
         <i class="icon ion-chevron-right"></i>
       </button>


### PR DESCRIPTION
To raise up user experience, also ng-click events for previous and next months are moved on parent div.