### PR TITLE
previous and next month events moved on parent div

### DIFF
--- a/src/ionic-datepicker-modal.html
+++ b/src/ionic-datepicker-modal.html
@@ -5,8 +5,8 @@
   <ion-content class="ionic_datepicker_modal_content">
     <div class="">
       <div class="row text-center">
-        <div class="col col-10 left_arrow">
-          <button class="button-clear font_22px" ng-click="prevMonth()"
+        <div class="col col-10 left_arrow" ng-click="prevMonth()">
+          <button class="button-clear font_22px"
                   ng-class="{'pointer_events_none':((firstDayEpoch - 86400000) < fromDate)}">
             <i class="icon ion-chevron-left"></i>
           </button>
@@ -31,8 +31,8 @@
             </div>
           </div>
         </div>
-        <div class="col col-10 right_arrow">
-          <button class=" button-clear font_22px" ng-click="nextMonth()"
+        <div class="col col-10 right_arrow" ng-click="nextMonth()">
+          <button class=" button-clear font_22px"
                   ng-class="{'pointer_events_none':((lastDayEpoch + 86400000)> toDate)}">
             <i class="icon ion-chevron-right"></i>
           </button>

--- a/src/ionic-datepicker-popup.html
+++ b/src/ionic-datepicker-popup.html
@@ -1,8 +1,8 @@
 <div class="selected_date_full">{{selctedDateEpoch | date : mainObj.dateFormat}}</div>
 <div class="date_selection">
   <div class="row show_nav">
-    <div class="col col-10 prev_btn_section">
-      <button class="button-clear" ng-click="prevMonth()"
+    <div class="col col-10 prev_btn_section" ng-click="prevMonth()">
+      <button class="button-clear"
               ng-class="{'pointer_events_none':((firstDayEpoch - 86400000) < fromDate)}">
         <i class="icon ion-chevron-left"></i>
       </button>
@@ -27,8 +27,8 @@
         </div>
       </div>
     </div>
-    <div class="col col-10 next_btn_section">
-      <button class="button-clear" ng-click="nextMonth()"
+    <div class="col col-10 next_btn_section" ng-click="nextMonth()">
+      <button class="button-clear"
               ng-class="{'pointer_events_none':((lastDayEpoch + 86400000)> toDate)}">
         <i class="icon ion-chevron-right"></i>
       </button>


### PR DESCRIPTION
ng-click events for previous and next month moved on parent div, because they where hard to trigger while tapping on the mobile device.