### PR TITLE
Fix: Today button on the popup didn't trigger the callback for date change

### DIFF
--- a/src/ionic-datepicker.provider.js
+++ b/src/ionic-datepicker.provider.js
@@ -268,6 +268,7 @@ angular.module('ionic-datepicker.provider', [])
               var today = new Date();
               refreshDateList(new Date());
               $scope.selctedDateEpoch = resetHMSM(today).getTime();
+              $scope.mainObj.callback($scope.selctedDateEpoch);
               if (!$scope.mainObj.closeOnSelect) {
                 e.preventDefault();
               }


### PR DESCRIPTION
Fixes a problem where when using the Popup version of the datepicker the `callback` wasn't triggered when the Today button is tapped.