### PR TITLE
Reset Today at Open

### DIFF
--- a/src/ionic-datepicker.provider.js
+++ b/src/ionic-datepicker.provider.js
@@ -230,7 +230,7 @@ angular.module('ionic-datepicker.provider', [])
         var buttons = [];
         delete $scope.fromDate;
         delete $scope.toDate;
-
+        $scope.today = resetHMSM(new Date()).getTime();
         $scope.mainObj = angular.extend({}, config, ipObj);
         if ($scope.mainObj.from) {
           $scope.fromDate = resetHMSM(new Date($scope.mainObj.from)).getTime();


### PR DESCRIPTION
If the module is in an open app over several days the $scope.today is not reset to reflect the correct current date.

Fixes #332